### PR TITLE
Fixed 6657133

### DIFF
--- a/test/reproducers/6657133/Test.java
+++ b/test/reproducers/6657133/Test.java
@@ -1,3 +1,5 @@
+package com.sun.imageio.plugins.jpeg;
+
 import java.security.AccessControlException;
 
 public

--- a/test/reproducers/6657133/Test.sh
+++ b/test/reproducers/6657133/Test.sh
@@ -3,16 +3,25 @@ echo $PWD
 FS="/"
 JAVAC=${TESTJAVA}${FS}bin${FS}javac
 JAVA=${TESTJAVA}${FS}bin${FS}java
+if [ "x$TESTSRC" == "x" ] ; then
+  TESTSRC="."
+fi
 
 $JAVAC -d . $TESTSRC/Test.java 
 R=$?
-if [[ $R -ne 0 ]] ; then
-  echo "On newer JDK compilationmust fail. OK - javacc returned $R"
-  exit 0
+if [ "0$R" -ne "0" ] ; then
+  echo "On newer JDK default compilation must fail. OK - javac returned $R"
+  # ok, how new jdk?
+  if ! ${JAVA}  -Djava.security.manager=allow -version | grep "Could not create SecurityManager" ; then
+   echo "jdk with no security manager, passing"
+   exit 0
+  else 
+   echo "jdk with security manager, but no com.sun.imageio.plugins.jpeg.JPEG class"
+   exit 0
+  fi
 fi
 
 # older JDK, here the reproducer must verify field is unaccessible
-
-$JAVA -Djava.security.manager Test
+$JAVA -Djava.security.manager com.sun.imageio.plugins.jpeg.Test
 R=$?
 exit $R


### PR DESCRIPTION
the test have no longer any meaning in jdk11+
in jdk8 change of package was needed to compiel it again
the main fix for GH actions was  in removal of [[ ]] in favour of [ ] 