### PR TITLE
1463098/cgroup-memory-limit-respected-systemd moved to be rh systems only

### DIFF
--- a/test/reproducers/1463098/cgroup-memory-limit-respected-systemd.sh
+++ b/test/reproducers/1463098/cgroup-memory-limit-respected-systemd.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # @test
 # @bug 1463098
-# @requires jdk.version.major >= 7 & var.msys2.enabled == "false"
+# @requires jdk.version.major >= 7 & var.msys2.enabled == "false" & var.rh.jdk == "true"
 # @summary cgroup memory limit not respected when run outside container
 # @run shell/timeout=120 cgroup-memory-limit-respected-systemd.sh
 


### PR DESCRIPTION
I saw this fail on aarch64 ubuntu and s390 something