### PR TITLE
Remade CheckAlgorithms.java test to be a little more advanced

### DIFF
--- a/test/reproducers/checkAlgorithms/CheckAlgorithms.java
+++ b/test/reproducers/checkAlgorithms/CheckAlgorithms.java
@@ -9,7 +9,7 @@ public class CheckAlgorithms {
     public static final List<String> FIPS_ALGORITHMS = Arrays.asList();
     public static final List<String> NONFIPS_ALGORITHMS = Arrays.asList("TLS_RSA_WITH_AES_128_CBC_SHA");
 
-    private static final List<String> possibleFirstArgs = Arrays.asList("assert", "true", "list", "false");
+    private static final List<String> possibleFirstArgs = Arrays.asList("assert", "true", "silent-assert", "list", "false");
     private static final List<String> possibleSecondArgs = Arrays.asList("algorithms", "providers", "both");
 
     public static void main(String[] args) throws Exception {
@@ -17,6 +17,7 @@ public class CheckAlgorithms {
             System.err.println("Test for listing available algorithms and providers and checking their FIPS compatibility");
             System.err.println("Usage: CheckAlgorithms " + possibleFirstArgs + " " + possibleSecondArgs);
             System.err.println("First argument: specify whether to check FIPS compatibility (assert/true) or just list the items (list/false)");
+            System.err.println("                silent-asserts just asserts, not lists the items");
             System.err.println("Second argument: specify what to check - algorithms, providers or both");
             System.exit(1);
         }
@@ -40,15 +41,16 @@ public class CheckAlgorithms {
         System.out.println("Test type: " + shouldHonorFips);
         System.out.println("What is tested: " + testCategory);
 
-        boolean honorFipsHere = shouldHonorFips.equals("assert") || shouldHonorFips.equals("true");
+        boolean listItems = !shouldHonorFips.equals("silent-assert");
+        boolean honorFipsHere = shouldHonorFips.equals("assert") || shouldHonorFips.equals("true") || shouldHonorFips.equals("silent-assert");
 
         boolean algorithmsOk = true;
         boolean providersOk = true;
         if (testCategory.equals("algorithms") || testCategory.equals("both")){
-            algorithmsOk = checkAlgorithms(honorFipsHere);
+            algorithmsOk = checkAlgorithms(listItems, honorFipsHere);
         }
         if (testCategory.equals("providers") || testCategory.equals("both")) {
-            providersOk = checkProviders(honorFipsHere);
+            providersOk = checkProviders(listItems, honorFipsHere);
         }
 
         // throwing the correct exception based on what failed (even if both failed)
@@ -61,13 +63,15 @@ public class CheckAlgorithms {
         }
     }
 
-    static boolean checkProviders(boolean shouldHonorFips) {
+    static boolean checkProviders(boolean listItems, boolean shouldHonorFips) {
         System.out.println(">>>CHECKING PROVIDERS<<<");
 
         // print all providers
-        System.out.println("LIST OF PROVIDERS:");
-        for(Provider provider : Security.getProviders()){
-            System.out.println("  " + provider);
+        if (listItems) {
+            System.out.println("LIST OF PROVIDERS:");
+            for(Provider provider : Security.getProviders()){
+                System.out.println("  " + provider);
+            }
         }
 
         if (shouldHonorFips) {
@@ -78,13 +82,15 @@ public class CheckAlgorithms {
         return true; // no assertion = everything is ok
     }
 
-    static boolean checkAlgorithms(boolean shouldHonorFips) throws Exception{
+    static boolean checkAlgorithms(boolean listItems, boolean shouldHonorFips) throws Exception{
         System.out.println(">>>CHECKING ALGORITHMS<<<");
 
         // print all algorithms
-        System.out.println("LIST OF ALGORITHMS:");
-        for (String cipher : CipherList.getCipherList()) {
-            System.out.println("  " + cipher);
+        if (listItems) {
+            System.out.println("LIST OF ALGORITHMS:");
+            for (String cipher : CipherList.getCipherList()) {
+                System.out.println("  " + cipher);
+            }
         }
 
         if (shouldHonorFips) {

--- a/test/reproducers/checkAlgorithms/CheckAlgorithms.java
+++ b/test/reproducers/checkAlgorithms/CheckAlgorithms.java
@@ -7,11 +7,14 @@ public class CheckAlgorithms {
     public static final String NONFIPS_PROVIDER = "SunPCSC";
     public static final String NONFIPS_ALGORITHM = "TLS_RSA_WITH_AES_128_CBC_SHA";
 
+    private static final List<String> possibleFirstArgs = Arrays.asList("assert", "true", "list", "false");
+    private static final List<String> possibleSecondArgs = Arrays.asList("algorithms", "providers", "both");
+
     public static void main(String[] args) throws Exception {
         if (args.length != 2 || args[0].equals("--help") || args[0].equals("-h")) {
             System.err.println("Test for listing available algorithms and providers and checking their FIPS compatibility");
-            System.err.println("Usage: CheckAlgorithms <true|false|only-algorithms|only-providers> <algorithms|providers|both>");
-            System.err.println("First argument: specify whether (and how) to check FIPS compatibility or not");
+            System.err.println("Usage: CheckAlgorithms " + possibleFirstArgs + " " + possibleSecondArgs);
+            System.err.println("First argument: specify whether to check FIPS compatibility (assert/true) or just list the items (list/false)");
             System.err.println("Second argument: specify what to check - algorithms, providers or both");
             System.exit(1);
         }
@@ -21,28 +24,26 @@ public class CheckAlgorithms {
         String testCategory = args[1].toLowerCase();
 
         // Check if the shouldHonorFips is valid value
-        List<String> possibleFirstArgs = Arrays.asList("true", "false", "only-algorithms", "only-providers");
         if (!possibleFirstArgs.contains(shouldHonorFips)) {
-            System.err.println("Invalid value for the first argument: " + args[0]);
+            System.err.println("Invalid value for the first argument: '" + args[0] + "', use --help for more info.");
             System.exit(1);
         }
 
-        // Check if the test category is "algorithms", "providers" or "both"
-        List<String> possibleSecondArgs = Arrays.asList("algorithms", "providers", "both");
+        // Check if the testCategory is valid value
         if (!possibleSecondArgs.contains(testCategory)) {
-            System.err.println("Invalid test category: " + args[1]);
+            System.err.println("Invalid test category: '" + args[1] + "', use --help for more info.");
             System.exit(1);
         }
 
         System.out.println("Is fips honoring expected? - " + shouldHonorFips);
         System.out.println("This test is set to test " + testCategory + " now.");
 
+        boolean honorFipsHere = shouldHonorFips.equals("assert") || shouldHonorFips.equals("true");
+
         if (testCategory.equals("algorithms") || testCategory.equals("both")){
-            boolean honorFipsHere = shouldHonorFips.equals("true") || shouldHonorFips.equals("only-algorithms");
             checkAlgorithms(honorFipsHere);
         }
         if (testCategory.equals("providers") || testCategory.equals("both")) {
-            boolean honorFipsHere = shouldHonorFips.equals("true") || shouldHonorFips.equals("only-providers");
             checkProviders(honorFipsHere);
         }
     }
@@ -95,5 +96,4 @@ public class CheckAlgorithms {
         return false;
     }
 }
-
 

--- a/test/reproducers/checkAlgorithms/CheckAlgorithms.java
+++ b/test/reproducers/checkAlgorithms/CheckAlgorithms.java
@@ -1,9 +1,5 @@
 import java.security.*;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.nio.file.Path;
 import java.util.List;
 
 public class CheckAlgorithms {
@@ -12,68 +8,82 @@ public class CheckAlgorithms {
     public static final String NONFIPS_ALGORITHM = "TLS_RSA_WITH_AES_128_CBC_SHA";
 
     public static void main(String[] args) throws Exception {
-	if (args.length != 2) {
-            System.err.println("Usage: CheckAlgorithms <true|false> <algorithms|providers>");
+        if (args.length != 2 || args[0].equals("--help") || args[0].equals("-h")) {
+            System.err.println("Test for listing available algorithms and providers and checking their FIPS compatibility");
+            System.err.println("Usage: CheckAlgorithms <true|false|only-algorithms|only-providers> <algorithms|providers|both>");
+            System.err.println("First argument: specify whether (and how) to check FIPS compatibility or not");
+            System.err.println("Second argument: specify what to check - algorithms, providers or both");
             System.exit(1);
         }
 
         // Parse the arguments
-        boolean shouldHonorFips = Boolean.parseBoolean(args[0]);
-        String testCategory = args[1];
+        String shouldHonorFips = args[0].toLowerCase();
+        String testCategory = args[1].toLowerCase();
 
-        // Check if the shouldHonorFips is "true" or "false"
-        if (!args[0].equalsIgnoreCase("true") && !args[0].equalsIgnoreCase("false")) {
+        // Check if the shouldHonorFips is valid value
+        List<String> possibleFirstArgs = Arrays.asList("true", "false", "only-algorithms", "only-providers");
+        if (!possibleFirstArgs.contains(shouldHonorFips)) {
             System.err.println("Invalid value for the first argument: " + args[0]);
             System.exit(1);
         }
 
-        // Check if the test category is "algorithms" or "providers"
-        if (!testCategory.equalsIgnoreCase("algorithms") && !testCategory.equalsIgnoreCase("providers")) {
-            System.err.println("Invalid test category: " + testCategory);
+        // Check if the test category is "algorithms", "providers" or "both"
+        List<String> possibleSecondArgs = Arrays.asList("algorithms", "providers", "both");
+        if (!possibleSecondArgs.contains(testCategory)) {
+            System.err.println("Invalid test category: " + args[1]);
             System.exit(1);
         }
 
-	System.out.println("Is fips honoring expected? - " + shouldHonorFips);
-	System.out.println("This test is set to test " + testCategory + " now.");
+        System.out.println("Is fips honoring expected? - " + shouldHonorFips);
+        System.out.println("This test is set to test " + testCategory + " now.");
 
-	if(testCategory.equals("algorithms")){
-	    checkAlgorithms(shouldHonorFips);
-	}
-	else {
-	    checkProviders(shouldHonorFips);
-	}
+        if (testCategory.equals("algorithms") || testCategory.equals("both")){
+            boolean honorFipsHere = shouldHonorFips.equals("true") || shouldHonorFips.equals("only-algorithms");
+            checkAlgorithms(honorFipsHere);
+        }
+        if (testCategory.equals("providers") || testCategory.equals("both")) {
+            boolean honorFipsHere = shouldHonorFips.equals("true") || shouldHonorFips.equals("only-providers");
+            checkProviders(honorFipsHere);
+        }
     }
 
     static void checkProviders(boolean shouldHonorFips) throws Exception{
-
-	//first half of the following condition checks that if we expect fips provider, there is a fips provider
-	//the second half checks that when we expect fips provider, the non-fips provider is not there
-	//inversion works as well.. 
-	if(providerFound(FIPS_PROVIDER) == shouldHonorFips && !providerFound(NONFIPS_PROVIDER) == shouldHonorFips){
-            return;
+        System.out.println(">>>LIST OF PROVIDERS:<<<");
+        for(Provider provider : Security.getProviders()){
+            System.out.println(provider);
         }
-        else{
-            throw new Exception("Test failed");
+
+        //checks that if we expect fips provider, there is a fips provider
+        if (shouldHonorFips && !providerFound(FIPS_PROVIDER)) {
+            throw new Exception("Test failed, FIPS provider was not found when honoring FIPS.");
+        }
+
+        //checks that when we except fips provider, the non-fips provider is not there
+        if(shouldHonorFips && providerFound(NONFIPS_PROVIDER)){
+            throw new Exception("Test failed, found non-FIPS provider when honoring FIPS.");
         }
     }
 
     static void checkAlgorithms(boolean shouldHonorFips) throws Exception{
-	String[] ciphers = CipherList.getCipherList();
-    	for(int i=0; ciphers.length > i; i++){
-            System.out.println(ciphers[i]);
-	}
-	if(algorithmFound(NONFIPS_ALGORITHM) == shouldHonorFips){
-	    throw new Exception("Test failed");
-	}	
+        System.out.println(">>>LIST OF ALGORITHMS:<<<");
+        for (String cipher : CipherList.getCipherList()) {
+            System.out.println(cipher);
+        }
+
+        //if the test found nonfips algorithm, and it should honor FIPS, throw an exception
+        //otherwise, everything is ok
+        if(shouldHonorFips && algorithmFound(NONFIPS_ALGORITHM)){
+            throw new Exception("Test failed, found non-FIPS algorithm when honoring FIPS.");
+        }
     }
 
     static boolean algorithmFound(String algorithm) throws Exception{
-    	for(String cipher : CipherList.getCipherList()){
-	    if(cipher.contains(algorithm)){
-	        return true;
-	    }
-	}
-	return false;	
+        for(String cipher : CipherList.getCipherList()){
+            if(cipher.contains(algorithm)){
+                return true;
+            }
+        }
+        return false;
     }
 
     static boolean providerFound(String provider){
@@ -85,4 +95,5 @@ public class CheckAlgorithms {
         return false;
     }
 }
+
 

--- a/test/reproducers/checkAlgorithms/CheckAlgorithms.java
+++ b/test/reproducers/checkAlgorithms/CheckAlgorithms.java
@@ -35,8 +35,8 @@ public class CheckAlgorithms {
             System.exit(1);
         }
 
-        System.out.println("Is fips honoring expected? - " + shouldHonorFips);
-        System.out.println("This test is set to test " + testCategory + " now.");
+        System.out.println("Test type: " + shouldHonorFips);
+        System.out.println("What is tested: " + testCategory);
 
         boolean honorFipsHere = shouldHonorFips.equals("assert") || shouldHonorFips.equals("true");
 
@@ -49,9 +49,11 @@ public class CheckAlgorithms {
     }
 
     static void checkProviders(boolean shouldHonorFips) throws Exception{
-        System.out.println(">>>LIST OF PROVIDERS:<<<");
+        System.out.println(">>>CHECKING PROVIDERS<<<");
+
+        System.out.println("LIST OF PROVIDERS:");
         for(Provider provider : Security.getProviders()){
-            System.out.println(provider);
+            System.out.println("  " + provider);
         }
 
         //checks that if we expect fips provider, there is a fips provider
@@ -66,9 +68,11 @@ public class CheckAlgorithms {
     }
 
     static void checkAlgorithms(boolean shouldHonorFips) throws Exception{
-        System.out.println(">>>LIST OF ALGORITHMS:<<<");
+        System.out.println(">>>CHECKING ALGORITHMS<<<");
+
+        System.out.println("LIST OF ALGORITHMS:");
         for (String cipher : CipherList.getCipherList()) {
-            System.out.println(cipher);
+            System.out.println("  " + cipher);
         }
 
         //if the test found nonfips algorithm, and it should honor FIPS, throw an exception


### PR DESCRIPTION
Updated `CheckAlgorithms.java`, these are the main changes:

- providers are now also printed, not just the algorithms
- I added another option for the second switch, for now it was only `algorithms` or `providers`, I added the option for `both` which first lists/checks the algorithms and then the providers
- apart from the `true/false` switches for checking FIPS compatibility, I added `only-algorithms` and `only-providers` for checking FIPS compatibility only on the specified category
- I added a brief help prompt
- I remade some logic for checking the FIPS compatibility and made the exceptions' texts more specific

Since there are still the same switches (`true/false` and `algorithms/providers`) in the same order available, the test should be backwards compatible and should not break anything.