### PR TITLE
Updated checkAlgorithms.java to be compatible with JDK8

### DIFF
--- a/test/reproducers/checkAlgorithms/CheckAlgorithms.java
+++ b/test/reproducers/checkAlgorithms/CheckAlgorithms.java
@@ -102,7 +102,7 @@ public class CheckAlgorithms {
     }
 
     static boolean algorithmAssert() throws Exception {
-        List<String> algorithms = List.of(CipherList.getCipherList());
+        List<String> algorithms = Arrays.asList(CipherList.getCipherList());
         boolean allOk = true;
 
         // assert that algorithms list contains all FIPS_ALGORITHMS
@@ -172,4 +172,3 @@ public class CheckAlgorithms {
         return allOk;
     }
 }
-


### PR DESCRIPTION
As the title says. I replaced `List.of()` method with `Arrays.asList()`, which should be JDK8 compatible.