### PR TITLE
8251945: exclude on jdk8 s390x as it does not have jfr

### DIFF
--- a/test/reproducers/8251945/PredefinedClassloaderCyclicBarrierCrash.java
+++ b/test/reproducers/8251945/PredefinedClassloaderCyclicBarrierCrash.java
@@ -12,6 +12,7 @@ import java.util.concurrent.Executors;
 /*
  * @test
  * @bug 8251945
+ * @requires (os.arch != "s390x" | jdk.version.major > 8)
  * @summary JDK-8251945 SIGSEGV in PackageEntry::purge_qualified_exports()
  * @run main/othervm/fail PredefinedClassloaderCyclicBarrierCrash
  */


### PR DESCRIPTION
Test uses `jdk.jfr.Event` but jdk8 on s390x does not have jfr. So exclude it there.