### PR TITLE
removing checkGitRepoSha reference from build.xml

### DIFF
--- a/aqa-tests/functional/jtreg-buffer/build.xml
+++ b/aqa-tests/functional/jtreg-buffer/build.xml
@@ -47,7 +47,6 @@
                                                                                would result to run the suite twice  -->
           <getFileWithRetry file="jtreg-buffer"
                command="git clone --depth 1 -q ${GIT_REPO}rh-openjdk/jtreg-buffer.git -b main jtreg-buffer ;  rm -rvf  jtreg-buffer/aqa-tests/" />
-          <checkGitRepoSha repoDir="jtreg-buffer" />
      </target>
 
      <target name="init">


### PR DESCRIPTION
is needed due to changes in: https://github.com/adoptium/TKG/commit/1b194139d7c6f915905d3984a5dfc16aba9a0618 
the referenced macro is no longer available.. local testing proved removing the line will solve the problem without introduction of any new problems (that I am aware of)

similarly in adoptium https://github.com/adoptium/aqa-tests/commit/8d9d402622f42cc041fce733e79bfebabc06169d  it seems that removing the line referencing the macro should be enough.